### PR TITLE
(small) bug fix

### DIFF
--- a/Data/_compromised/ar_Arabic/ar.Rmd
+++ b/Data/_compromised/ar_Arabic/ar.Rmd
@@ -113,7 +113,7 @@ Grapheme  Phoneme      Comment
 "ي"       "/j/; /iː/"   "/j/: word -initially (used as default in the rules); /iː/ preceded by a short /i/ diacritic"
 "ء"       "/ʔ/"         "called a hamza, this grapheme also exists as a diacritic (explained below)"
 "ة"       "∅; /t/"      "called a ta-marbuta, this grapheme appears word-finally, corresponding to /t/ if followed by a diacritic or ∅ otherwise [@Biadsy2009, p. 3]"
-"ى"       "/a/"         "called an alif-maqsura, this grapheme occurs word-finally [@Habash2010, p. 11; @Biadsy2009, p. 3]"      
+"ى"       "/a̱/"         "called an alif-maqsura, this grapheme occurs word-finally [@Habash2010, p. 11; @Biadsy2009, p. 3]"      
 **Diacritic**    ""     ""
 "ُ"       "/u/"          "this diacritic is called a dammah [@Yurtbasi2016, p. 146]"
 "َ"       "/a/"          "this diacritic is called a fatḥah (ibid.)"

--- a/docs/Convert-to-IPA-keepspace.html
+++ b/docs/Convert-to-IPA-keepspace.html
@@ -242,7 +242,7 @@
                 <div class="d-flex flex-column gap">
                   <div class="row m-0">
                     <div class="col p-0">
-                      Phonemic Representation:
+                      Phonetic Representation:
                     </div>
                     <div class="col p-0 text-right">
                        <a id="translations_file" title="Click to download as list" download>Download</a><br>

--- a/docs/Convert-to-IPA.html
+++ b/docs/Convert-to-IPA.html
@@ -242,7 +242,7 @@
                 <div class="d-flex flex-column gap">
                   <div class="row m-0">
                     <div class="col p-0">
-                      Phonemic Representation:
+                      Phonetic Representation:
                     </div>
                     <div class="col p-0 text-right">
                        <a id="translations_file" title="Click to download as list" download>Download</a><br>


### PR DESCRIPTION
Corrected spelling errors
changed /a/ to /a̱/ in arabic for the letter ى